### PR TITLE
Update generator.context with the reordered list

### DIFF
--- a/pin_to_top.py
+++ b/pin_to_top.py
@@ -2,22 +2,24 @@
 Pin to top plugin for Pelican
 ================================
 
-Adds .pin variable to article's context and pins the article to the top 
+Adds .pin variable to article's context and pins the article to the top
  even if it is older than the other articles
 """
 from pelican import signals
-  
-def update_pinned_articles(generator): 
-    new_order = [] 
+
+def update_pinned_articles(generator):
+    new_order = []
     # count articles and keep the pinned ordered by date
-    pinned = 0; 
-    for article in generator.context['articles']:
-        if hasattr(article,'pin'): 
+    pinned = 0;
+    for article in generator.articles:
+        if hasattr(article,'pin'):
             new_order.insert(pinned,article)
-            pinned += 1 
-        else: 
+            pinned += 1
+        else:
             new_order.append(article)
-    generator.context['articles'] = new_order
+    generator.articles = new_order
+    # Update the context with the new list
+    generator.context['articles'] = generator.articles
 
 def register():
     signals.article_generator_finalized.connect(update_pinned_articles)


### PR DESCRIPTION
For templates not using pagination, they will fetch directly the articles from the context.

Problem description:
The context was updated already in `generate_context` with:

```
self._update_context(('articles', 'dates', 'tags', 'categories',
                          'tag_cloud', 'authors', 'related_posts'))
```

This plugin is called afterwards:

```
signals.article_generator_finalized.send(self)
```

In the plugin the article list is updated, but not the context. When a template is called the context contains the original article list, not the updated one. If the template fetch the articles from the context then the plugin seems to have no effect.

This patch corrects it. Not sure if asigning the article list directly to the context can cause some secondary effect.
