### PR TITLE
Add capability to pin an article for category or author only

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Edit your *pelicanconf.py*:
 
 In your article(s) meta data you can use: 
 
-    Pin: true 
+    Pin: true
+
+In your article(s) you can pin the article to the top of a category by:
+
+    pin_to_category: true
+
+In you article(s) you can pin the article to the top of an author by:
+
+    pin_to_author: true
     
 Later you can also use it in your theme, for example you can use the glyphicon-pushpin:
 

--- a/pin_to_top.py
+++ b/pin_to_top.py
@@ -7,13 +7,25 @@ Adds .pin variable to article's context and pins the article to the top
 """
 from pelican import signals
 
+def is_attr_true(obj, attribute):
+    attrib = getattr(obj, attribute, 'False')
+    if attrib in [False, 0]:
+        return False
+    try:
+        if attrib.lower() in ["f", "0", "false"]:
+            return False
+    except AttributeError:
+        return False
+    return True
+
+
 def update_pinned_articles(generator):
     new_order = []
     # count articles and keep the pinned ordered by date
     pinned = 0;
     for article in generator.articles:
-        if hasattr(article,'pin'):
-            new_order.insert(pinned,article)
+        if is_attr_true(article, 'pin'):
+            new_order.insert(pinned, article)
             pinned += 1
         else:
             new_order.append(article)
@@ -21,5 +33,44 @@ def update_pinned_articles(generator):
     # Update the context with the new list
     generator.context['articles'] = generator.articles
 
+
+def update_pinned_articles_by_category(generator):
+    new_categories = []
+    for category, articles in generator.categories:
+        # count articles and keep the pinned ordered by date
+        new_order = []
+        pinned = 0;
+        for article in articles:
+            if is_attr_true(article, 'pin_to_category') and getattr(article, 'category') == category._name:
+                new_order.insert(pinned, article)
+                pinned += 1
+            else:
+                new_order.append(article)
+        new_categories.append((category, new_order))
+    generator.categories = new_categories
+    # Update the context with the new list
+    generator.context['categories'] = new_categories
+
+
+def update_pinned_articles_by_author(generator):
+    new_authors = []
+    for author, articles in generator.authors:
+        # count articles and keep the pinned ordered by date
+        new_order = []
+        pinned = 0;
+        for article in articles:
+            if is_attr_true(article, 'pin_to_author') and getattr(article, 'author') == author._name:
+                new_order.insert(pinned, article)
+                pinned += 1
+            else:
+                new_order.append(article)
+        new_authors.append((author, new_order))
+    generator.authors = new_authors
+    # Update the context with the new list
+    generator.context['authors'] = new_authors
+
+
 def register():
     signals.article_generator_finalized.connect(update_pinned_articles)
+    signals.article_generator_finalized.connect(update_pinned_articles_by_category)
+    signals.article_generator_finalized.connect(update_pinned_articles_by_author)


### PR DESCRIPTION
I added the capability to pin an article to the top for a given category or author. This allows an author to pin an introductory article for a category or an author.

I also added a code snippet  to handle attributes in a way so that 
Pin: False 

will NOT pin the article.